### PR TITLE
fix(native_fetch): use fetch if available

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,4 +1,4 @@
-var native_fetch = typeof(fetch) !== "undefined" && native_fetch;
+var native_fetch = typeof(fetch) !== "undefined" && fetch;
 
 module.exports = native_fetch || function(url, params) {
   var thens   = [];


### PR DESCRIPTION
Currently your fetch method is always used even if window.fetch is available.